### PR TITLE
Updated Expo version to be compatible with SDK 33 and 34

### DIFF
--- a/examples/app.json
+++ b/examples/app.json
@@ -4,7 +4,7 @@
     "description": "This project is really great.",
     "slug": "examples",
     "privacy": "public",
-    "sdkVersion": "31.0.0",
+    "sdkVersion": "33.0.0",
     "platforms": ["ios", "android"],
     "version": "1.0.0",
     "orientation": "portrait",

--- a/examples/package.json
+++ b/examples/package.json
@@ -13,7 +13,7 @@
     "expo": "^33.0.0",
     "react": "16.8.3",
     "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
-    "react-native-bottom-bar": "AndersGerner/react-native-bottom-bar#expo",
+    "react-native-bottom-bar": "WrathChaos/react-native-bottom-bar#expo",
     "react-native-elements": "^0.19.1",
     "react-native-iphone-x-helper": "^1.2.0",
     "react-native-typography": "^1.4.0",

--- a/examples/package.json
+++ b/examples/package.json
@@ -10,10 +10,10 @@
     "eject": "expo eject"
   },
   "dependencies": {
-    "expo": "^31.0.2",
-    "react": "16.5.0",
-    "react-native": "https://github.com/expo/react-native/archive/sdk-31.0.0.tar.gz",
-    "react-native-bottom-bar": "WrathChaos/react-native-bottom-bar#expo",
+    "expo": "^33.0.0",
+    "react": "16.8.3",
+    "react-native": "https://github.com/expo/react-native/archive/sdk-33.0.0.tar.gz",
+    "react-native-bottom-bar": "AndersGerner/react-native-bottom-bar#expo",
     "react-native-elements": "^0.19.1",
     "react-native-iphone-x-helper": "^1.2.0",
     "react-native-typography": "^1.4.0",

--- a/lib/src/components/MainIconButton.js
+++ b/lib/src/components/MainIconButton.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import { Platform, View, TouchableOpacity } from "react-native";
-import { LinearGradient } from "expo";
+import { LinearGradient } from "expo-linear-gradient";
 import { Icon } from "react-native-elements";
 import colors from "./styles/common/colors";
 import sharedStyle, { defaultShadowStyle } from "./styles/common/shared.style";

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-native": ">= 0.55.x",
     "react-native-elements": ">= 0.19",
     "react-native-iphone-x-helper": ">= 1.2",
-    "react-native-vector-icons": ">= 6.0"
+    "react-native-vector-icons": ">= 6.0",
+    "expo-linear-gradient": "~6.0.0"
   },
   "devDependencies": {
     "babel-preset-expo": "^5.0.0",


### PR DESCRIPTION
There has been a change in how to import libraries from Expo.
This change will ensure it works with both SDK 33 and 34.

Let me know if you have any feedback, then I will fix :) 

Thanks a great library!